### PR TITLE
Protocol: Add a trailing slash to `Application`

### DIFF
--- a/Protocol.php
+++ b/Protocol.php
@@ -114,7 +114,7 @@ class Protocol extends Node
 
         $this[] = new Node(
             'Application',
-            $cwd,
+            $cwd . DS,
             [
                 new Node('Public', 'Public' . DS)
             ]


### PR DESCRIPTION
If missing, it can corrupt some existing applications in the wild.