### PR TITLE
Checks whether hoa protocol is already defined

### DIFF
--- a/Wrapper.php
+++ b/Wrapper.php
@@ -577,7 +577,9 @@ class Wrapper
 /**
  * Register the `hoa://` protocol.
  */
-stream_wrapper_register('hoa', 'Hoa\Protocol\Wrapper');
+if (!in_array('hoa', stream_get_wrappers())) {
+    stream_wrapper_register('hoa', 'Hoa\Protocol\Wrapper');
+}
 
 }
 


### PR DESCRIPTION
Fixes PHP Warning:  stream_wrapper_register(): Protocol hoa:// is already defined. in /var/www/project/vendor/hoa/protocol/Wrapper.php on line 580